### PR TITLE
Handle additional mimeTypes for zip files

### DIFF
--- a/server/src/managers/GraphicsStore.ts
+++ b/server/src/managers/GraphicsStore.ts
@@ -188,7 +188,7 @@ export class GraphicsStore {
 
     console.log("Uploaded file", file.originalname, file.size);
 
-    if (file.mimetype !== "application/x-zip-compressed") {
+    if (!["application/x-zip-compressed","application/zip"].includes(file.mimetype)) {
       ctx.status = 400;
       ctx.body = literal<ServerAPI.ErrorReturnValue>({
         code: 400,


### PR DESCRIPTION
Hi there,

We've been trying to upload files from a MacOS devices (running Firefox as the browser) which have been using a slightly different Mime Type `application/zip`. 

I've included this in the `GraphicsStore.ts`, `uploadGraphic()` function to allow this.
