### PR TITLE
Enabled as open web service in Open Source Cloud

### DIFF
--- a/CHANGELOG-OSC.md
+++ b/CHANGELOG-OSC.md
@@ -1,0 +1,11 @@
+# Eyevinn Open Source Cloud - Processing History
+
+This file tracks when this project was processed by the Eyevinn Open Source Cloud service builder.
+
+## Changelog
+
+- **2025-12-09T22:44:10.296Z**: Project synchronized with upstream by OSaaS Service Builder
+
+---
+
+*This changelog is automatically maintained by the [OSaaS Service Builder](https://www.osaas.io)*

--- a/CHANGELOG-OSC.md
+++ b/CHANGELOG-OSC.md
@@ -4,6 +4,7 @@ This file tracks when this project was processed by the Eyevinn Open Source Clou
 
 ## Changelog
 
+- **2026-03-21T00:00:00.000Z**: OSC supply pipeline processed by AI agent — added Dockerfile.osc, osc-entrypoint.sh, fixed PORT env var, OSC_HOSTNAME→controller URL injection, configurable graphics storage path, S3/MinIO sync support (issue #76)
 - **2025-12-09T22:44:10.296Z**: Project synchronized with upstream by OSaaS Service Builder
 
 ---

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,12 @@
+FROM node:18-alpine
+RUN apk add python3 make g++
+ENV NODE_ENV=production
+ENV PORT=8080
+RUN mkdir /app
+RUN chown node:node /app
+WORKDIR /app
+USER node
+COPY --chown=node:node ["./", "./"]
+RUN NODE_ENV="" npm ci || npm install --include=dev --production=false
+RUN npm run build
+CMD ["npm", "run", "start"]

--- a/Dockerfile.osc
+++ b/Dockerfile.osc
@@ -1,0 +1,60 @@
+FROM node:20-alpine AS builder
+
+RUN apk add --no-cache python3 make g++
+
+# Enable corepack for yarn 4
+RUN corepack enable
+
+WORKDIR /build
+COPY package.json yarn.lock .yarnrc.yml ./
+COPY packages/server/package.json packages/server/package.json
+COPY packages/controller/package.json packages/controller/package.json
+COPY packages/renderer-layer/package.json packages/renderer-layer/package.json
+COPY packages/shared/package.json packages/shared/package.json
+
+RUN yarn install --immutable
+
+COPY packages/ packages/
+
+RUN yarn build
+
+# ---- Runtime image ----
+FROM node:20-alpine
+
+RUN apk add --no-cache bash aws-cli
+
+# Enable corepack for yarn 4
+RUN corepack enable
+
+ENV NODE_ENV=production
+ENV PORT=8080
+
+WORKDIR /app
+
+# Copy workspace root config
+COPY --from=builder /build/package.json /build/yarn.lock /build/.yarnrc.yml ./
+
+# Copy built packages
+COPY --from=builder /build/packages/server/package.json packages/server/package.json
+COPY --from=builder /build/packages/server/dist packages/server/dist
+COPY --from=builder /build/packages/server/public packages/server/public
+COPY --from=builder /build/packages/renderer-layer/package.json packages/renderer-layer/package.json
+COPY --from=builder /build/packages/renderer-layer/dist packages/renderer-layer/dist
+COPY --from=builder /build/packages/controller/package.json packages/controller/package.json
+COPY --from=builder /build/packages/controller/dist packages/controller/dist
+COPY --from=builder /build/packages/shared/package.json packages/shared/package.json
+COPY --from=builder /build/packages/shared/dist packages/shared/dist
+
+# Yarn workspace hoists all deps to root node_modules
+COPY --from=builder /build/node_modules node_modules
+
+# Create data directory for persistent graphics storage
+RUN mkdir -p /data/localGraphicsStorage
+
+EXPOSE 8080
+
+COPY --chmod=755 osc-entrypoint.sh /usr/local/bin/osc-entrypoint.sh
+ENTRYPOINT ["/usr/local/bin/osc-entrypoint.sh"]
+# Run from packages/server so relative paths (../controller/dist etc.) resolve correctly
+WORKDIR /app/packages/server
+CMD ["node", "dist/main.js"]

--- a/README-OSC.md
+++ b/README-OSC.md
@@ -1,0 +1,49 @@
+# Eyevinn Open Source Cloud
+
+## Turn Your Open Source Project into a Revenue Stream
+
+Welcome to [Eyevinn Open Source Cloud](https://www.osaas.io) - the platform that democratizes infrastructure and creates sustainable revenue for open source creators.
+
+### Why Eyevinn Open Source Cloud Benefits You as a Creator
+
+**🚀 Zero Infrastructure Costs**  
+Your users get enterprise-grade hosting and scaling without you managing servers, paying hosting bills, or dealing with DevOps complexity. We handle the infrastructure so you can focus on what you do best - building great software.
+
+**💰 Monetize Your Open Source Work**  
+Finally get paid for your contributions to the open source ecosystem. When users deploy your project through our platform, you automatically receive a share of the revenue. No complicated pricing models or payment processing required.
+
+**📈 Reach More Users**  
+Remove the biggest barrier to adoption - deployment complexity. Your project becomes instantly accessible to non-technical users and small teams who need your solution but lack the resources for self-hosting.
+
+**🎯 Level the Playing Field**  
+Small and medium projects now have access to the same infrastructure capabilities as big tech companies. Your innovative tool can compete on features, not on who has the biggest infrastructure budget.
+
+### How It Works
+
+1. **Claim Ownership**: Create your account on [osaas.io](https://www.osaas.io) and connect your GitHub account
+2. **Automatic Recognition**: We verify your ownership of this repository
+3. **Instant Revenue**: Start earning from every deployment of your project
+4. **Focus on Code**: Continue developing while we handle scaling, security, and operations
+
+### For Your Users
+
+Users pay only for what they use, getting professional-grade hosting without the complexity. They can deploy your project in minutes instead of hours or days, making your solution accessible to a broader audience.
+
+### Community & Support
+
+Join our vibrant community of open source creators:
+
+- **💬 [Slack Workspace](https://slack.osaas.io)** - Connect with other creators, get help, and share your experiences
+- **🐙 [GitHub](https://github.com/EyevinnOSC)** - Contribute to the platform and follow development updates  
+- **💼 [LinkedIn](https://www.linkedin.com/company/eyevinn-open-source-cloud/)** - Stay updated with news and announcements
+- **📚 [Documentation](https://docs.osaas.io)** - User guides and best practices
+
+### Join the Movement
+
+Help us democratize access to open source infrastructure and create a sustainable ecosystem where creators are rewarded for their contributions.
+
+**[Get Started →](https://www.osaas.io)**
+
+---
+
+*Eyevinn Open Source Cloud - Making open source more accessible, one deployment at a time.*

--- a/osc-entrypoint.sh
+++ b/osc-entrypoint.sh
@@ -1,0 +1,42 @@
+#!/bin/bash
+set -e
+
+# Set graphics storage path to persistent volume
+export GRAPHICS_STORAGE_PATH="${GRAPHICS_STORAGE_PATH:-/data/localGraphicsStorage}"
+mkdir -p "$GRAPHICS_STORAGE_PATH"
+
+# OSC_HOSTNAME → used by server.ts to inject the correct API URL into the controller UI
+# (No export needed here; server.ts reads process.env.OSC_HOSTNAME directly)
+
+# S3/MinIO sync for graphics storage
+# Set S3_GRAPHICS_URL to enable bidirectional sync with an S3-compatible bucket
+# Set S3_ENDPOINT_URL for MinIO or other non-AWS endpoints (e.g. https://minio.example.com)
+ENDPOINT_ARG=""
+if [ -n "$S3_ENDPOINT_URL" ]; then
+  ENDPOINT_ARG="--endpoint-url $S3_ENDPOINT_URL"
+  echo "[OSC] Using custom S3 endpoint: $S3_ENDPOINT_URL"
+fi
+
+SYNC_INTERVAL="${S3_SYNC_INTERVAL:-60}"
+
+if [ -n "$S3_GRAPHICS_URL" ]; then
+  echo "[OSC] Performing initial S3 graphics download from $S3_GRAPHICS_URL..."
+  aws s3 sync "$S3_GRAPHICS_URL" "$GRAPHICS_STORAGE_PATH" $ENDPOINT_ARG 2>&1 | while IFS= read -r line; do
+    echo "[S3 Graphics Init] $line"
+  done
+
+  echo "[OSC] Starting bidirectional S3 graphics sync (interval: ${SYNC_INTERVAL}s, source of truth: S3)"
+  (
+    while true; do
+      sleep "$SYNC_INTERVAL"
+      aws s3 sync "$GRAPHICS_STORAGE_PATH" "$S3_GRAPHICS_URL" $ENDPOINT_ARG 2>&1 | while IFS= read -r line; do
+        echo "[S3 Graphics Upload] $line"
+      done
+      aws s3 sync "$S3_GRAPHICS_URL" "$GRAPHICS_STORAGE_PATH" --delete $ENDPOINT_ARG 2>&1 | while IFS= read -r line; do
+        echo "[S3 Graphics Download] $line"
+      done
+    done
+  ) &
+fi
+
+exec "$@"

--- a/osc-entrypoint.sh
+++ b/osc-entrypoint.sh
@@ -5,8 +5,11 @@ set -e
 export GRAPHICS_STORAGE_PATH="${GRAPHICS_STORAGE_PATH:-/data/localGraphicsStorage}"
 mkdir -p "$GRAPHICS_STORAGE_PATH"
 
-# OSC_HOSTNAME → used by server.ts to inject the correct API URL into the controller UI
-# (No export needed here; server.ts reads process.env.OSC_HOSTNAME directly)
+# Map OSC_HOSTNAME to PUBLIC_URL for the server to derive client-facing URLs
+if [ -n "$OSC_HOSTNAME" ] && [ -z "$PUBLIC_URL" ]; then
+  export PUBLIC_URL="https://${OSC_HOSTNAME}"
+  echo "[OSC] PUBLIC_URL set to $PUBLIC_URL"
+fi
 
 # S3/MinIO sync for graphics storage
 # Set S3_GRAPHICS_URL to enable bidirectional sync with an S3-compatible bucket

--- a/packages/controller/src/stores/appSettings.ts
+++ b/packages/controller/src/stores/appSettings.ts
@@ -8,7 +8,7 @@ import { clone } from '../lib/lib.js'
 class AppSettings {
 	private LOCALSTORAGE_ID = 'appSettings'
 
-	public serverApiUrl = 'http://localhost:8080/ograf/v1/'
+	public serverApiUrl = (window as any).__OGRAF_SERVER_URL__ || `${window.location.origin}/ograf/v1/`
 	public selectedRendererId: string = ''
 
 	private ografApi = OgrafApi.getSingleton()
@@ -19,7 +19,14 @@ class AppSettings {
 		try {
 			const stateToLoad: StoredState | undefined = stateToLoadStr ? JSON.parse(stateToLoadStr) : undefined
 
-			if (stateToLoad?.serverApiUrl) this.serverApiUrl = stateToLoad.serverApiUrl
+			// Prefer injected OSC server URL; fall back to stored URL only if it's not a localhost URL
+			const injectedUrl: string | undefined = (window as any).__OGRAF_SERVER_URL__
+			const storedUrl = stateToLoad?.serverApiUrl
+			if (injectedUrl) {
+				this.serverApiUrl = injectedUrl
+			} else if (storedUrl && !storedUrl.includes('localhost')) {
+				this.serverApiUrl = storedUrl
+			}
 			if (stateToLoad?.selectedRendererId) this.selectedRendererId = stateToLoad.selectedRendererId
 			if (stateToLoad?.queuedGraphics) {
 				stateToLoad.queuedGraphics.forEach(([key, value]) => this.queuedGraphics.set(key, value))

--- a/packages/renderer-layer/src/App.tsx
+++ b/packages/renderer-layer/src/App.tsx
@@ -29,10 +29,15 @@ export const App: React.FC = () => {
 
 		/** URL to send server requests to: */
 		const serverApiUrl = 'http://localhost:8080'
-		/** URL to open websocket connection to */
-		// const rendererApiUrl = 'ws://localhost:8080/rendererApi/v1'
-		const rendererApiUrl = 'ws://localhost:8080'
-		// const rendererApiUrl = 'ws://google.com'
+		/** URL to open websocket connection to.
+		 * Use injected OSC WebSocket URL if available, otherwise derive from window.location.
+		 */
+		const injectedWsUrl = (window as any).__OGRAF_WS_URL__
+		const rendererApiUrl =
+			injectedWsUrl ||
+			(window.location.protocol === 'https:'
+				? `wss://${window.location.host}`
+				: `ws://${window.location.host}`)
 
 		const graphicCache = new GraphicCache(serverApiUrl)
 		const layersManager = new LayersManager(graphicCache)

--- a/packages/renderer-layer/src/App.tsx
+++ b/packages/renderer-layer/src/App.tsx
@@ -27,10 +27,12 @@ export const App: React.FC = () => {
 
 		document.title = `Renderer | ${rendererName}`
 
-		/** URL to send server requests to: */
-		const serverApiUrl = 'http://localhost:8080'
+		/** URL to send server requests to.
+		 * Use injected server URL if available, otherwise derive from window.location.
+		 */
+		const serverApiUrl = (window as any).__OGRAF_SERVER_URL__ || window.location.origin
 		/** URL to open websocket connection to.
-		 * Use injected OSC WebSocket URL if available, otherwise derive from window.location.
+		 * Use injected WebSocket URL if available, otherwise derive from window.location.
 		 */
 		const injectedWsUrl = (window as any).__OGRAF_WS_URL__
 		const rendererApiUrl =

--- a/packages/server/public/index.html
+++ b/packages/server/public/index.html
@@ -75,13 +75,13 @@
               </li>
               <li>
                 <b>Open an OGraf Renderer</b> in your HTML renderer (such as CasparCG, OBS, Vmix, etc).<br />
-                <i>Use the URL: <a href="http://localhost:8080/renderer/renderer-layer/index.html?name=Renderer-window&id=1&background=1" target="_blank">
-                  http://localhost:8080/renderer/renderer-layer/index.html
+                <i>Use the URL: <a href="/renderer/renderer-layer/index.html?name=Renderer-window&id=1&background=1" target="_blank">
+                  /renderer/renderer-layer/index.html
                 </a>
                 </i>
                 <ul>
                   <li>
-                    CasparCG command: <pre>PLAY 1-10 [html] http://localhost:8080/renderer/renderer-layer/index.html</pre>
+                    CasparCG command: <pre>PLAY 1-10 [html] http://&lt;server-address&gt;/renderer/renderer-layer/index.html</pre>
                   </li>
                 </ul>
               </li>

--- a/packages/server/src/managers/GraphicsStore.ts
+++ b/packages/server/src/managers/GraphicsStore.ts
@@ -7,7 +7,7 @@ import { CTX } from '../lib/lib.js'
 
 export class GraphicsStore {
 	/** File path where to store Graphics */
-	private FILE_PATH = path.resolve('./localGraphicsStorage')
+	private FILE_PATH = path.resolve(process.env.GRAPHICS_STORAGE_PATH || './localGraphicsStorage')
 	/** How long to wait before removing Graphics, in ms */
 	private REMOVAL_WAIT_TIME = 1000 * 3600 * 24 // 24 hours
 

--- a/packages/server/src/server.ts
+++ b/packages/server/src/server.ts
@@ -33,6 +33,12 @@ export async function initializeServer(): Promise<void> {
 	setupServerApi(httpRouter, graphicsStore, rendererManager) // HTTP API (ServerAPI)
 	setupRendererApi(wsRouter, rendererManager) // WebSocket API (RendererAPI)
 
+	// Derive the public base URL from PUBLIC_URL env var, falling back to localhost.
+	// PUBLIC_URL can be set by a deployment entrypoint (e.g., from a platform hostname).
+	const PORT = process.env.PORT || '8080'
+	const publicUrl = process.env.PUBLIC_URL || `http://localhost:${PORT}`
+	const publicWsUrl = publicUrl.replace(/^https:/, 'wss:').replace(/^http:/, 'ws:')
+
 	// Set up static file serving:
 	httpRouter.get('/', async (ctx: Koa.ParameterizedContext) => {
 		await serveFile(ctx, path.resolve('./public/index.html'))
@@ -51,12 +57,9 @@ export async function initializeServer(): Promise<void> {
 	httpRouter.get(/\/controller\/.*/, async (ctx: Koa.ParameterizedContext) => {
 		const relPath = ctx.path.trim().replace(/^\/controller\//, '')
 		const controllerDist = path.resolve('../controller/dist')
-		// Inject OSC_SERVER_URL into index.html so the controller uses the correct server URL
+		// Inject server URL into index.html so the controller uses the correct server URL
 		if (relPath === 'index.html' || relPath === '') {
-			const oscHostname = process.env.OSC_HOSTNAME
-			const serverUrl = oscHostname
-				? `https://${oscHostname}/ograf/v1/`
-				: `http://localhost:${process.env.PORT || '8080'}/ograf/v1/`
+			const serverUrl = `${publicUrl}/ograf/v1/`
 			const htmlPath = path.join(controllerDist, 'index.html')
 			try {
 				const html = await fs.readFile(htmlPath, 'utf8')
@@ -77,18 +80,14 @@ export async function initializeServer(): Promise<void> {
 	httpRouter.get(/\/renderer\/.*/, async (ctx: Koa.ParameterizedContext) => {
 		const relPath = ctx.path.trim().replace(/^\/renderer\//, '')
 		const rendererDist = path.resolve('../renderer-layer/dist')
-		// Inject OSC_WS_URL into renderer index.html so the renderer uses the correct WebSocket URL
+		// Inject server URL and WebSocket URL into renderer index.html
 		if (relPath === 'index.html' || relPath === '') {
-			const oscHostname = process.env.OSC_HOSTNAME
-			const wsUrl = oscHostname
-				? `wss://${oscHostname}`
-				: `ws://localhost:${process.env.PORT || '8080'}`
 			const htmlPath = path.join(rendererDist, 'index.html')
 			try {
 				const html = await fs.readFile(htmlPath, 'utf8')
 				const injected = html.replace(
 					'<head>',
-					`<head><script>window.__OGRAF_WS_URL__ = ${JSON.stringify(wsUrl)};</script>`
+					`<head><script>window.__OGRAF_SERVER_URL__ = ${JSON.stringify(publicUrl)};window.__OGRAF_WS_URL__ = ${JSON.stringify(publicWsUrl)};</script>`
 				)
 				ctx.set('Content-Type', 'text/html')
 				ctx.set('charset', 'utf-8')
@@ -110,10 +109,10 @@ export async function initializeServer(): Promise<void> {
 
 	app.use(filter.protocols())
 
-	const PORT = parseInt(process.env.PORT || '8080', 10)
+	const port = parseInt(PORT, 10)
 
-	app.listen(PORT)
-	console.log(`Server running on \x1b[36m http://127.0.0.1:${PORT}/\x1b[0m`)
+	app.listen(port)
+	console.log(`Server running on \x1b[36m http://127.0.0.1:${port}/\x1b[0m`)
 }
 
 async function serveFromPath(ctx: Koa.ParameterizedContext, folderPath: string, url: string) {

--- a/packages/server/src/server.ts
+++ b/packages/server/src/server.ts
@@ -74,6 +74,32 @@ export async function initializeServer(): Promise<void> {
 		}
 		await serveFromPath(ctx, controllerDist, relPath)
 	})
+	httpRouter.get(/\/renderer\/.*/, async (ctx: Koa.ParameterizedContext) => {
+		const relPath = ctx.path.trim().replace(/^\/renderer\//, '')
+		const rendererDist = path.resolve('../renderer-layer/dist')
+		// Inject OSC_WS_URL into renderer index.html so the renderer uses the correct WebSocket URL
+		if (relPath === 'index.html' || relPath === '') {
+			const oscHostname = process.env.OSC_HOSTNAME
+			const wsUrl = oscHostname
+				? `wss://${oscHostname}`
+				: `ws://localhost:${process.env.PORT || '8080'}`
+			const htmlPath = path.join(rendererDist, 'index.html')
+			try {
+				const html = await fs.readFile(htmlPath, 'utf8')
+				const injected = html.replace(
+					'<head>',
+					`<head><script>window.__OGRAF_WS_URL__ = ${JSON.stringify(wsUrl)};</script>`
+				)
+				ctx.set('Content-Type', 'text/html')
+				ctx.set('charset', 'utf-8')
+				ctx.body = injected
+				return
+			} catch {
+				// Fall through to normal serving
+			}
+		}
+		await serveFromPath(ctx, rendererDist, relPath)
+	})
 	// httpRouter.get("/renderer/*", async (ctx) => {
 
 	//   // ctx.body = await fs.readFile("./public/index.html", "utf8");

--- a/packages/server/src/server.ts
+++ b/packages/server/src/server.ts
@@ -49,7 +49,30 @@ export async function initializeServer(): Promise<void> {
 	//   await serveFile(ctx, path.resolve("../controller/dist/index.html"));
 	// });
 	httpRouter.get(/\/controller\/.*/, async (ctx: Koa.ParameterizedContext) => {
-		await serveFromPath(ctx, path.resolve('../controller/dist'), ctx.path.trim().replace(/^\/controller\//, ''))
+		const relPath = ctx.path.trim().replace(/^\/controller\//, '')
+		const controllerDist = path.resolve('../controller/dist')
+		// Inject OSC_SERVER_URL into index.html so the controller uses the correct server URL
+		if (relPath === 'index.html' || relPath === '') {
+			const oscHostname = process.env.OSC_HOSTNAME
+			const serverUrl = oscHostname
+				? `https://${oscHostname}/ograf/v1/`
+				: `http://localhost:${process.env.PORT || '8080'}/ograf/v1/`
+			const htmlPath = path.join(controllerDist, 'index.html')
+			try {
+				const html = await fs.readFile(htmlPath, 'utf8')
+				const injected = html.replace(
+					'<head>',
+					`<head><script>window.__OGRAF_SERVER_URL__ = ${JSON.stringify(serverUrl)};</script>`
+				)
+				ctx.set('Content-Type', 'text/html')
+				ctx.set('charset', 'utf-8')
+				ctx.body = injected
+				return
+			} catch {
+				// Fall through to normal serving
+			}
+		}
+		await serveFromPath(ctx, controllerDist, relPath)
 	})
 	// httpRouter.get("/renderer/*", async (ctx) => {
 
@@ -61,7 +84,7 @@ export async function initializeServer(): Promise<void> {
 
 	app.use(filter.protocols())
 
-	const PORT = 8080
+	const PORT = parseInt(process.env.PORT || '8080', 10)
 
 	app.listen(PORT)
 	console.log(`Server running on \x1b[36m http://127.0.0.1:${PORT}/\x1b[0m`)


### PR DESCRIPTION
Hi,

With this Pull Request we want to give you the option to add a badge to your README to show that
your software is available as an open web service in [Eyevinn Open Source Cloud](www.osaas.io).
With Eyevinn Open Source Cloud we turn open source into open web services and share the revenue
with the creators. 

Our goal with this platform is to reduce the barrier to get started with open source and contribute
to a sustainable business for open source by giving back a share of the revenue to the creators.
For our customers we can offer full code transparency and no vendor lock-in as all web services
are open source.

We want to *not be evil* and we do this to provide the creators with an additional
income stream for their projects.

Our pledge to the community is to:

 - §1. Share revenue that is generated by an open source project with the creator.
 - §2. Ensure that any modifications made to a project are available to the public 
       as a public fork.
 - §3. Never, ever, take open source code and turn it into closed source.
 - §4. Always provide our customers with the option to self-host the very same code 
       and never lock in to our platform or the underlying infrastructure.
 - §5. Remove the project from our platform if requested by the creator.

To claim ownership and receive a revenue share follow the instructions in 
the [documentation for creators](https://docs.osaas.io/osaas.wiki/Creator.html).

Jonas Birme
CTO Eyevinn Open Source Cloud