### PR TITLE
hide white border on graphic load

### DIFF
--- a/packages/renderer-layer/src/scss/styles.scss
+++ b/packages/renderer-layer/src/scss/styles.scss
@@ -1,1 +1,5 @@
+iframe {
+    border-style: none;
+}
+
 // Custom CSS:


### PR DESCRIPTION
When loading ograf graphic, a thin white border appears. adding the following css to the renderer layer solves it

```css
iframe {
    border-style: none;
}
```

<img width="880" height="635" alt="Screenshot 2026-06-20 at 22 41 24" src="https://github.com/user-attachments/assets/db8333e0-806f-469b-a933-171721e59682" />
<img width="996" height="594" alt="Screenshot 2026-06-20 at 22 41 03" src="https://github.com/user-attachments/assets/a9be122d-3429-480d-bdb8-56b8720ca7cb" />
