### PR TITLE
fix: update server and websocket URLs to use dynamic host

### DIFF
--- a/packages/renderer-layer/src/App.tsx
+++ b/packages/renderer-layer/src/App.tsx
@@ -28,11 +28,9 @@ export const App: React.FC = () => {
 		document.title = `Renderer | ${rendererName}`
 
 		/** URL to send server requests to: */
-		const serverApiUrl = 'http://localhost:8080'
+		const serverApiUrl = `http://${window.location.host}`
 		/** URL to open websocket connection to */
-		// const rendererApiUrl = 'ws://localhost:8080/rendererApi/v1'
-		const rendererApiUrl = 'ws://localhost:8080'
-		// const rendererApiUrl = 'ws://google.com'
+		const rendererApiUrl = `ws://${window.location.host}`
 
 		const graphicCache = new GraphicCache(serverApiUrl)
 		const layersManager = new LayersManager(graphicCache)


### PR DESCRIPTION
When using the ograf-server renderer from a remote machine (where the Node.js server is running on a different host than CasparCG), the renderer fails to establish the WebSocket connection because the WebSocket URL is hardcoded to localhost. This prevents remote deployments from working correctly. It might be beneficial to make the WebSocket host configurable, or derive it dynamically instead of assuming localhost.